### PR TITLE
updated from return to gruvbox to return to user's default colorscheme

### DIFF
--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -15,7 +15,8 @@ function Flashbang.setup(opts)
     local function deploy()
         sound.play("flashbang")
         local timer = vim.loop.new_timer()
-
+        local current = vim.g.colors_name
+        print(current)
         timer:start(
             1300,
             0,
@@ -26,7 +27,7 @@ function Flashbang.setup(opts)
                     duration,
                     0,
                     vim.schedule_wrap(function()
-                        vim.cmd("colorscheme gruvbox")
+                        vim.cmd("colorscheme " .. current)
                         vim.cmd("set background=dark")
                     end)
                 )


### PR DESCRIPTION
Get the user's previous theme before deploying flashbang to avoid gruvbox default.