### PR TITLE
Optional random recurrent deploy

### DIFF
--- a/lua/flashbang/config.lua
+++ b/lua/flashbang/config.lua
@@ -6,6 +6,7 @@ local Flashbang = {}
 --- Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 Flashbang.options = {
+    enabled = true,
     min_interval = 5,
     max_interval = 20,
     duration = 2.5,

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -4,7 +4,7 @@ local sound = require("flashbang.sound")
 local Flashbang = {}
 
 local function deploy()
-    local duration = _G.Flashbang.config.duration * 1000
+    local duration = config.options.duration * 1000
     sound.play("flashbang")
     local timer = vim.uv.new_timer()
     local current = vim.g.colors_name

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -2,7 +2,6 @@ local config = require("flashbang.config")
 local sound = require("flashbang.sound")
 
 local Flashbang = {}
-_G.Flashbang.config = config.setup({})
 
 local function deploy()
     local duration = _G.Flashbang.config.duration * 1000
@@ -37,21 +36,23 @@ function Flashbang.setup(opts)
 
     sound.detect_provider()
 
-    local min_interval = _G.Flashbang.config.min_interval * 1000 * 60
-    local max_interval = _G.Flashbang.config.max_interval * 1000 * 60
+    if _G.Flashbang.config.enabled then
+        local min_interval = _G.Flashbang.config.min_interval * 1000 * 60
+        local max_interval = _G.Flashbang.config.max_interval * 1000 * 60
 
-    local timer = vim.uv.new_timer()
-    local function recurring_deploy()
-        timer:start(
-            math.random(min_interval, max_interval),
-            0,
-            vim.schedule_wrap(function()
-                deploy()
-                recurring_deploy()
-            end)
-        )
+        local timer = vim.uv.new_timer()
+        local function recurring_deploy()
+            timer:start(
+                math.random(min_interval, max_interval),
+                0,
+                vim.schedule_wrap(function()
+                    deploy()
+                    recurring_deploy()
+                end)
+            )
+        end
+        recurring_deploy()
     end
-    recurring_deploy()
 end
 
 _G.Flashbang = Flashbang

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -2,14 +2,10 @@ local config = require("flashbang.config")
 local sound = require("flashbang.sound")
 
 local Flashbang = {}
+_G.Flashbang.config = config.setup({})
 
 local function deploy()
-    local duration = 2.5 * 1000
-    local light_theme = "dalek"
-    if config ~= nil then
-        duration = config.options.duration * 1000
-        light_theme = _G.Flashbang.config.light_theme
-    end
+    local duration = _G.Flashbang.config.duration * 1000
     sound.play("flashbang")
     local timer = vim.uv.new_timer()
     local current = vim.g.colors_name
@@ -17,7 +13,7 @@ local function deploy()
         1300,
         0,
         vim.schedule_wrap(function()
-            vim.cmd("colorscheme " .. light_theme)
+            vim.cmd("colorscheme " .. _G.Flashbang.config.light_theme)
             vim.cmd("set background=light")
             timer:start(
                 duration,

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -5,8 +5,10 @@ local Flashbang = {}
 
 local function deploy()
     local duration = 2.5 * 1000
+    local light_theme = "dalek"
     if config ~= nil then
         duration = config.options.duration * 1000
+        light_theme = _G.Flashbang.config.light_theme
     end
     sound.play("flashbang")
     local timer = vim.uv.new_timer()
@@ -15,7 +17,7 @@ local function deploy()
         1300,
         0,
         vim.schedule_wrap(function()
-            vim.cmd("colorscheme " .. _G.Flashbang.config.light_theme)
+            vim.cmd("colorscheme " .. light_theme)
             vim.cmd("set background=light")
             timer:start(
                 duration,

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -4,7 +4,7 @@ local sound = require("flashbang.sound")
 local Flashbang = {}
 
 local function deploy()
-    local duration = config.options.duration * 1000
+    local duration = (config.options.duration or 2.5) * 1000
     sound.play("flashbang")
     local timer = vim.uv.new_timer()
     local current = vim.g.colors_name

--- a/lua/flashbang/init.lua
+++ b/lua/flashbang/init.lua
@@ -4,7 +4,10 @@ local sound = require("flashbang.sound")
 local Flashbang = {}
 
 local function deploy()
-    local duration = (config.options.duration or 2.5) * 1000
+    local duration = 2.5 * 1000
+    if config ~= nil then
+        duration = config.options.duration * 1000
+    end
     sound.play("flashbang")
     local timer = vim.uv.new_timer()
     local current = vim.g.colors_name


### PR DESCRIPTION
Added enabled flag to make the random flashbangs optional and allow library use of the plugin's deploy() function.
